### PR TITLE
feat: toggleable CC metrics

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -12,6 +12,10 @@ minecraft {
 
 dependencies {
     compileOnlyApi(libs.jsr305)
+
+    // Core libraries
     implementation(libs.bundles.prometheus)
-    compileOnly(libs.bundles.common)
+    compileOnly(libs.bundles.forgeConfig)
+    // Extra mods
+    compileOnly(libs.cct.forge) // We don't ship a common mod jar.
 }

--- a/common/src/main/java/cc/tweaked/prometheus/Config.java
+++ b/common/src/main/java/cc/tweaked/prometheus/Config.java
@@ -5,7 +5,6 @@ import net.minecraftforge.common.ForgeConfigSpec;
 public final class Config {
     public static final ForgeConfigSpec.ConfigValue<String> host;
     public static final ForgeConfigSpec.ConfigValue<Integer> port;
-    public static final ForgeConfigSpec.ConfigValue<Boolean> computercraft;
     public static final ForgeConfigSpec.ConfigValue<Boolean> vanilla;
     public static final ForgeConfigSpec.ConfigValue<Boolean> jvm;
 
@@ -21,11 +20,6 @@ public final class Config {
         port = configBuilder
             .comment("The port the Prometheus exporter should be hosted on.")
             .defineInRange("port", 9226, 1, 65535);
-
-        computercraft = configBuilder
-            .comment("Whether to expose ComputerCraft metrics.")
-            .worldRestart()
-            .define("computercraft", true);
 
         vanilla = configBuilder
             .comment("Whether to expose some metrics about the state of the vanilla server.")

--- a/common/src/main/java/cc/tweaked/prometheus/Config.java
+++ b/common/src/main/java/cc/tweaked/prometheus/Config.java
@@ -5,6 +5,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 public final class Config {
     public static final ForgeConfigSpec.ConfigValue<String> host;
     public static final ForgeConfigSpec.ConfigValue<Integer> port;
+    public static final ForgeConfigSpec.ConfigValue<Boolean> computercraft;
     public static final ForgeConfigSpec.ConfigValue<Boolean> vanilla;
     public static final ForgeConfigSpec.ConfigValue<Boolean> jvm;
 
@@ -20,6 +21,10 @@ public final class Config {
         port = configBuilder
             .comment("The port the Prometheus exporter should be hosted on.")
             .defineInRange("port", 9226, 1, 65535);
+
+        computercraft = configBuilder
+            .comment("Whether to expose ComputerCraft metrics.")
+            .define("computercraft", true);
 
         vanilla = configBuilder
             .comment("Whether to expose some metrics about the state of the vanilla server.")

--- a/common/src/main/java/cc/tweaked/prometheus/Config.java
+++ b/common/src/main/java/cc/tweaked/prometheus/Config.java
@@ -24,14 +24,17 @@ public final class Config {
 
         computercraft = configBuilder
             .comment("Whether to expose ComputerCraft metrics.")
+            .worldRestart()
             .define("computercraft", true);
 
         vanilla = configBuilder
             .comment("Whether to expose some metrics about the state of the vanilla server.")
+            .worldRestart()
             .define("vanilla", false);
 
         jvm = configBuilder
             .comment("Whether to expose some metrics about the state of the Java runtime.")
+            .worldRestart()
             .define("jvm", false);
 
         spec = configBuilder.build();

--- a/common/src/main/java/cc/tweaked/prometheus/ServerMetrics.java
+++ b/common/src/main/java/cc/tweaked/prometheus/ServerMetrics.java
@@ -29,11 +29,17 @@ public final class ServerMetrics {
         var ticking = ServerMetrics.toTick = new ArrayList<>();
         var registry = new MetricContext(server, collectorRegistry, ticking::add);
 
-        ComputerCollector.register(registry);
-        ComputerFieldCollector.register(registry);
-        ThreadGroupCollector.register(registry);
+        if (Config.computercraft.get()) {
+            ComputerCollector.register(registry);
+            ComputerFieldCollector.register(registry);
+            ThreadGroupCollector.register(registry);
+        }
         if (Config.vanilla.get()) VanillaCollector.export(registry);
         if (Config.jvm.get()) DefaultExports.register(collectorRegistry);
+
+        if (!collectorRegistry.metricFamilySamples().hasMoreElements()) {
+            LOG.warn("Warning: no collectors are enabled! Check the configuration.");
+        }
 
         try {
             ServerMetrics.server = new HTTPServer.Builder()

--- a/common/src/main/java/cc/tweaked/prometheus/ServerMetrics.java
+++ b/common/src/main/java/cc/tweaked/prometheus/ServerMetrics.java
@@ -31,7 +31,7 @@ public final class ServerMetrics {
 
         var computercraftLoaded = false;
         try {
-            Class.forName("dan200.computercraft.impl.ComputerCraftAPIImpl");
+            Class.forName("dan200.computercraft.api.ComputerCraftAPI");
             computercraftLoaded = true;
         } catch (ClassNotFoundException ignored) {
             LOG.warn("ComputerCraft not found, not registering ComputerCraft metrics");

--- a/common/src/main/java/cc/tweaked/prometheus/ServerMetrics.java
+++ b/common/src/main/java/cc/tweaked/prometheus/ServerMetrics.java
@@ -29,19 +29,12 @@ public final class ServerMetrics {
         var ticking = ServerMetrics.toTick = new ArrayList<>();
         var registry = new MetricContext(server, collectorRegistry, ticking::add);
 
-        var computercraftLoaded = false;
-        try {
-            Class.forName("dan200.computercraft.api.ComputerCraftAPI");
-            computercraftLoaded = true;
-        } catch (ClassNotFoundException ignored) {
-            LOG.warn("ComputerCraft not found, not registering ComputerCraft metrics");
-        }
-
-        if (computercraftLoaded) {
+        if (classExists("dan200.computercraft.api.ComputerCraftAPI")) {
             ComputerCollector.register(registry);
             ComputerFieldCollector.register(registry);
             ThreadGroupCollector.register(registry);
         }
+
         if (Config.vanilla.get()) VanillaCollector.export(registry);
         if (Config.jvm.get()) DefaultExports.register(collectorRegistry);
 
@@ -74,5 +67,14 @@ public final class ServerMetrics {
 
     public static void onServerTick() {
         for (var action : toTick) action.run();
+    }
+
+    private static boolean classExists(String name) {
+        try {
+            Class.forName(name, false, ServerMetrics.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
     }
 }

--- a/common/src/main/java/cc/tweaked/prometheus/ServerMetrics.java
+++ b/common/src/main/java/cc/tweaked/prometheus/ServerMetrics.java
@@ -29,7 +29,15 @@ public final class ServerMetrics {
         var ticking = ServerMetrics.toTick = new ArrayList<>();
         var registry = new MetricContext(server, collectorRegistry, ticking::add);
 
-        if (Config.computercraft.get()) {
+        var computercraftLoaded = false;
+        try {
+            Class.forName("dan200.computercraft.impl.ComputerCraftAPIImpl");
+            computercraftLoaded = true;
+        } catch (ClassNotFoundException ignored) {
+            LOG.warn("ComputerCraft not found, not registering ComputerCraft metrics");
+        }
+
+        if (computercraftLoaded) {
             ComputerCollector.register(registry);
             ComputerFieldCollector.register(registry);
             ThreadGroupCollector.register(registry);

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     implementation(libs.bundles.prometheus)
     modImplementation(libs.bundles.forgeConfig)
     // Extra mods
-    modCompileOnly(libs.cct.fabric)
+    modImplementation(libs.cct.fabric)
 
     include(libs.bundles.prometheus)
     include(libs.bundles.forgeConfig)

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -22,22 +22,18 @@ dependencies {
         },
     )
 
-    modImplementation(libs.bundles.fabric)
+    modImplementation(libs.fabric.loader)
+    modImplementation(libs.fabric.api)
+    // Core libraries
     implementation(libs.bundles.prometheus)
+    modImplementation(libs.bundles.forgeConfig)
+    // Extra mods
+    modCompileOnly(libs.cct.fabric)
+
     include(libs.bundles.prometheus)
+    include(libs.bundles.forgeConfig)
 
     implementation(project(":common"))
-
-//     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
-//
-//     implementation project(":common")
-//
-//     modImplementation ("cc.tweaked:cc-tweaked-${minecraft_version}-fabric:${cct_version}")
-//
-//     // IDK how Fabric config works (so much seems to be client-only??), so just copy CC:R.
-//     implementation 'com.electronwill.night-config:toml:3.6.5'
-//     include 'com.electronwill.night-config:core:3.6.5'
-//     include 'com.electronwill.night-config:toml:3.6.5'
 }
 
 loom {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -22,7 +22,9 @@
         "fabricloader": ">=0.14",
         "fabric": "*",
         "minecraft": "1.19.x",
-        "java": ">=17",
+        "java": ">=17"
+    },
+    "recommends": {
         "computercraft": "*"
     }
 }

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -44,7 +44,9 @@ dependencies {
 
     compileOnly(project(":common"))
 
+    // Core libraries
     minecraftEmbed(libs.bundles.prometheus)
+    // Extra mods
     implementation(fg.deobf(libs.cct.forge.get()))
 }
 

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -25,7 +25,7 @@ Hosts a Prometheus server with various ComputerCraft related statistics
 
 [[dependencies.ccprometheus]]
     modId="computercraft"
-    mandatory=true
+    mandatory=false
     versionRange="[1.102.0,)"
     ordering="NONE"
     side="BOTH"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,4 @@ prometheus = [
     "prometheus-core", "prometheus-common", "prometheus-server", "prometheus-hotspot",
     "prometheus-tracerCommon", "prometheus-tracerOtel", "prometheus-tracerOtelAgent"
 ]
-
-common = ["cct-forge", "forgeConfig", "nightConfig-core", "nightConfig-toml"]
-fabric = ["fabric-loader", "fabric-api", "cct-fabric", "forgeConfig", "nightConfig-core", "nightConfig-toml"]
-forge = ["cct-forge"]
+forgeConfig = ["forgeConfig", "nightConfig-core", "nightConfig-toml"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ nightConfig-core = { module = "com.electronwill.night-config:core", version.ref 
 nightConfig-toml = { module = "com.electronwill.night-config:toml", version.ref = "nightConfig" }
 
 prometheus-core = { module = "io.prometheus:simpleclient", version.ref = "prometheus" }
+prometheus-common = { module = "io.prometheus:simpleclient_common", version.ref = "prometheus" }
 prometheus-server = { module = "io.prometheus:simpleclient_httpserver", version.ref = "prometheus" }
 prometheus-hotspot = { module = "io.prometheus:simpleclient_hotspot", version.ref = "prometheus" }
 # All the transitive deps of prometheus.
@@ -54,7 +55,7 @@ shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
 
 [bundles]
 prometheus = [
-    "prometheus-core", "prometheus-server", "prometheus-hotspot",
+    "prometheus-core", "prometheus-common", "prometheus-server", "prometheus-hotspot",
     "prometheus-tracerCommon", "prometheus-tracerOtel", "prometheus-tracerOtelAgent"
 ]
 


### PR DESCRIPTION
This adds a config option, `computercraft`, to enable/disable the CC metrics. This makes cc-prometheus usable as a standalone vanilla/JVM metrics exporter without requiring CC in the environment. Totally understand if this is out of scope for the mod so feel free to reject, I just thought it might make more sense than me pulling out half the exporter code.

I left the startup phase as-is since the config can't be read during mod initialization. It works fine in testing for Fabric so hopefully there are no problems with that. I have not tested Forge. For both loaders, the CC mod is no longer marked as mandatory.

I also added a missing dependency, `simpleclient_common`, which was causing issues under Fabric.